### PR TITLE
Conformor prevent clash

### DIFF
--- a/alphas/clash_validator.py
+++ b/alphas/clash_validator.py
@@ -8,6 +8,9 @@ class ClashValidator:
 
     def __init__(self):
         self.clashes = 0
+        # VDW = {"N":1.55, "CA":1.7, "C":1.7, "O":1.52}
+        VDW = np.array([1.55, 1.7, 1.7, 1.52])
+        self.allowed_distances = np.add.outer(VDW,VDW)
 
     def clash_found_vectorized(self, new_chain, last_chain):
         """
@@ -23,14 +26,12 @@ class ClashValidator:
         # get the euclidean distance between each atom
         distances = distance.cdist(last_chain_vector, new_chain_vector, 'euclidean')
 
-        # VDW = {"N":1.55, "CA":1.7, "C":1.7, "O":1.52}
-        VDW = np.array([1.55, 1.7, 1.7, 1.52])
-        allowed_distances = np.add.outer(VDW,VDW)
         x, y = distances.shape
         #the extra slicing is to allow us to include the last 3 atoms
-        allowed_distances = np.tile(allowed_distances, (math.ceil(x/4), math.ceil(y/4)))[:,:y] 
+        allowed_distances = np.tile(self.allowed_distances, (math.ceil(x/4), math.ceil(y/4)))[:,:y] 
 
         clashes = (distances < allowed_distances)
+
         if np.any(clashes):
                 self.clashes += 1
                 return True
@@ -44,14 +45,10 @@ class ClashValidator:
         last_chain_vector = np.array([atoms_array for residue in last_chain[:-2] for atoms_array in residue.values()])
         new_chain_vector = np.array([atoms_array for residue in new_chain for atoms_array in residue.values()])
 
+        # init kdtrees
         last_chain_kdtree = KDTree(last_chain_vector)
         new_chain_kdtree = KDTree(new_chain_vector)
 
-        # VDW = {"N":1.55, "CA":1.7, "C":1.7, "O":1.52}
-        VDW = np.array([1.55, 1.7, 1.7, 1.52])
-        allowed_distances = np.add.outer(VDW,VDW)
-
-        # VDW = {"N":1.55, "CA":1.7, "C":1.7, "O":1.52}
         clashes = last_chain_kdtree.sparse_distance_matrix(new_chain_kdtree, 3.4) #maximum value to consider
         for indices, distance in zip(clashes.keys(),clashes.values()):
             if distance <= 3.04:
@@ -61,10 +58,6 @@ class ClashValidator:
             row = indices[0] % 4
             column = indices[1] % 4
 
-            if distance <= allowed_distances[row, column]:
+            if distance <= self.allowed_distances[row, column]:
                 return True
-        
         return False
-
-
-        print(clashes)

--- a/alphas/conformer_builder.py
+++ b/alphas/conformer_builder.py
@@ -521,10 +521,10 @@ class ConformerBuilder:
                 continue
 
             try:
-                clash_found = self.clash_validator.clash_found(self.conformer.coords[len(last_conformer):], last_conformer.coords)
+                clash_found = self.clash_validator.clash_found_vectorized(self.conformer.coords[len(last_conformer):], last_conformer.coords)
             except ValueError:
                 # added COO only
-                clash_found = self.clash_validator.clash_found(self.conformer.coords[-1:], last_conformer.coords[:-1])
+                clash_found = self.clash_validator.clash_found_vectorized(self.conformer.coords[-1:], last_conformer.coords[:-1])
 
             if not clash_found:
                 # no clashes, save this loop


### PR DESCRIPTION
Removing clashes implementation is done.

Reduced the four for loops and 2 if statements to just 2 for loops by vectorizing the calculations.
These could be reduced to 0 for loops eventually if we vectorize the whole program.

Reasonable assumptions made while developing:

* Any individual loop from the loop database does not have clashes within, therefore no checks are made on individual loops
* loops are not smaller than 2 residues

**EDITED (by @joaomcteixeira):**
This PR addresses #26.