### PR TITLE
added aa 1to3 and 3to1 dictionaries

### DIFF
--- a/src/idpconfgen/core/definitions.py
+++ b/src/idpconfgen/core/definitions.py
@@ -1,6 +1,32 @@
 """Static definitions that serve the whole program infrastructure."""
 from argparse import Namespace
 
+# Amino-acid 3 to 1 letter code dictionary
+aa3to1 = {
+    'ALA': 'A',
+    'ARG': 'R',
+    'ASN': 'N',
+    'ASP': 'D',
+    'CYS': 'C',
+    'GLU': 'E',
+    'GLN': 'Q',
+    'GLY': 'G',
+    'HIS': 'H',
+    'ILE': 'I',
+    'LEU': 'L',
+    'LYS': 'K',
+    'MET': 'M',
+    'PHE': 'F',
+    'PRO': 'P',
+    'SER': 'S',
+    'THR': 'T',
+    'TRP': 'W',
+    'TYR': 'Y',
+    'VAL': 'V'}
+
+# Amino-acid 1 to 3 letter code dictionary
+aa1to3 = {v:k for k, v in aa3to1.items()}
+
 
 # keys from https://github.com/cmbi/dssp/blob/7c2942773cd37d47b3e4611597d5e1eb886d95ba/src/dssp.cpp#L66-L74  # noqa:
 dssp_ss_keys = Namespace(
@@ -30,3 +56,5 @@ dssp_ss_keys.all_loops = (
     dssp_ss_keys.bend,
     dssp_ss_keys.loop,
     )
+
+

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -1,0 +1,20 @@
+"""
+This module tests interfaces in definitions.
+
+No enphasis is placed on actual definitions.
+"""
+import pytest
+
+from idpconfgen.core.definitions import (
+    aa3to1,
+    aa1to3,
+    )
+
+
+@pytest.mark.parametrize(
+    'aadict',
+    [aa3to1, aa1to3],
+    )
+def test_aa_letter_dictionaries(aadict):
+    assert isinstance(aadict, dict)
+    assert len(aadict) == 20  # there are 20 natural aminoacids


### PR DESCRIPTION
Adds dictionaries to translate aminoacid codes from 3 to 1 letter codes and vice-versa.