### PR TITLE
Corrects Exceptions instantiation

### DIFF
--- a/src/idpconfgen/core/__init__.py
+++ b/src/idpconfgen/core/__init__.py
@@ -23,3 +23,16 @@ def has_string_formatters(s):
     except IndexError:
         #  when string is ''
         return False
+
+
+def count_string_formatters(s):
+    """
+    Count string formatters: ``{}``.
+
+    Returns
+    -------
+    int
+        The number of string formatters.
+    """
+    assert isinstance(s, str), f'`s` of wrong type: {type(s)}'
+    return sum(1 for f in list(string.Formatter().parse(s)) if f[1] is not None)

--- a/src/idpconfgen/core/exceptions.py
+++ b/src/idpconfgen/core/exceptions.py
@@ -1,7 +1,7 @@
 """IDP Conf Gen Exceptions."""
 from idpconfgen import log
 from idpconfgen import contactus as CONTACTUS
-from idpconfgen.core import has_string_formatters
+from idpconfgen.core import count_string_formatters
 
 
 class IDPConfGenException(Exception):
@@ -37,49 +37,31 @@ class IDPConfGenException(Exception):
     """
 
     errmsg = 'An unknnown error as occurred. ' + CONTACTUS.contact_message
-
+    
     def __init__(self, *args, errmsg=None):
-        # require
-        assert errmsg is None or isinstance(errmsg, str), \
-            f'`errmsg` invalid type: {type(errmsg)}'
 
-        args = [str(a) for a in args]
-         
         # IDPConfGenException(errmsg='Custom error msg')
         if errmsg is not None:
+            assert isinstance(errmsg, str), f'wrong errmsg type: {type(errmsg)}'
             self.errmsg = errmsg
             self.args = []
- 
-        # IDPConfGenException('An error happened')
-        elif len(args) == 1:
-            if has_string_formatters(self.errmsg):
-                self.args = args
-             
-            else:
-                self.errmsg = args[0]
-                self.args = []
- 
-        elif len(args) > 1:
-            # IDPConfGenException('An error happened: {}, {}', var1, var2)
-            if has_string_formatters(args[0]):
-                self.errmsg = args[0]
-                self.args = args[1:]
-           
-            # IDPCalculator(var1, var2)
-            else:
-                self.args = args
-    
-        # ATTENTION: self.args exists from default from Exception Base class
-        # Yet I didn't want to change the variable name
-        else:
+
+        elif len(args) == count_string_formatters(self.errmsg):
             self.args = args
+    
+        else:
+            assert count_string_formatters(args[0]) == len(args[1:]), \
+                'args passed to Exception are not compatible to form a message'
+            self.errmsg = args[0]
+            self.args = args[1:]
 
         log.debug(f'Exception errors: {self.errmsg}')
         log.debug(f'Exception args: {self.args}')
 
         # ensure
-        assert isinstance(self.args, (tuple, list)), f'{type(self.args)}'
-        assert self.errmsg.count('{}') == len(self.args), (
+        assert isinstance(self.args, (tuple, list)), \
+            f'wrong args {type(self.args)}'
+        assert count_string_formatters(self.errmsg) == len(self.args), (
             'Bad Exception message:\n'
             f'errmsg: {self.errmsg}\n'
             f'args: {self.args}'
@@ -105,29 +87,35 @@ class IDPConfGenException(Exception):
 
 class PDBIDFactoryError(IDPConfGenException):
     """General PDBIDFactory Exception."""
+
     pass
 
 
 class DownloadFailedError(IDPConfGenException):
     """Raise when download fails."""
+
     pass
 
 
 class EmptyFilterError(IDPConfGenException):
     """Raise when PDB data filtering returns an empty selection."""
+  
     errmsg = 'Filter returns empty selection.'
 
 
 class DSSPParserError(IDPConfGenException):
     """Raise when libs.libparse.DSSPParserError needs it."""
+
     errmsg = 'Error while parsing {}'
 
 
 class DSSPSecStructError(IDPConfGenException):
     """Raise when libs.libparse.DSSPParserError needs it."""
+
     errmsg = 'Values differ from possible DSSP secondary structure keys.'
 
 
 class DSSPInputMissingError(IDPConfGenException):
     """Raise when libs.libparse.DSSPParserError needs it."""
+
     errmsg = 'One of the two required positional arguments is missing.'

--- a/src/idpconfgen/libs/libparse.py
+++ b/src/idpconfgen/libs/libparse.py
@@ -119,7 +119,7 @@ class DSSPParser:
     def _confirm_ss_data(data):
         # confirms data makes sense
         if not all((i in vars(DEFS.dssp_ss_keys).values() for i in data)):
-            raise EXCPTS.DSSPSecStructError(data)
+            raise EXCPTS.DSSPSecStructError()
 
     @staticmethod
     def _finds_data_index(data):

--- a/tests/tcommons.py
+++ b/tests/tcommons.py
@@ -1,4 +1,5 @@
 """Common funcs and variables for tests."""
+import random
 
 from idpconfgen import Path
 
@@ -13,3 +14,17 @@ folder_output = Path(
     tests_folder,
     'data_out_scratch',
     )
+
+
+def random_type():
+    types = [
+        1,
+        1.0,
+        [1,2],
+        {'a': 1},
+        None,
+        {},
+        [],
+        set(),
+        ]
+    return random.choice(types)


### PR DESCRIPTION
Corrects #41 

Redefines `IDPConfGenException` **contract** and **tests**.
Corrects instantiation of DSSPParser Exceptions in `libparse.py`.