### PR TITLE
dummy data generator

### DIFF
--- a/alphas/dummy_data_generator.py
+++ b/alphas/dummy_data_generator.py
@@ -29,9 +29,21 @@ aminoacids = list(aa3to1.values())
 SSletters = ['L', 'H', 'S']
 
 
-def generate_fout_name():
-    letters = [random.choice(string.ascii_uppercase) for i in range(4)]
-    return '{}{}{}{}_{}.data'.format(random.randint(0, 9), *letters)
+class NameGenerator:
+    def __init__(self):
+        self.names = []
+
+    def generate_fout_name(self):
+        name = self._generate()
+        while name in self.names:
+            name = self._generate()
+        
+        self.names.append(name)
+        return name
+          
+    def _generate(self):
+        letters = [random.choice(string.ascii_uppercase) for i in range(4)]
+        return '{}{}{}{}_{}.data'.format(random.randint(0, 9), *letters)
 
 
 def generate_fasta():
@@ -80,7 +92,9 @@ def generate_CA_coords(length):
 
 def generate_dummy_data():
     
-    fout_name = generate_fout_name()
+    name_generator = NameGenerator()
+
+    fout_name = name_generator.generate_fout_name()
 
     fasta = generate_fasta()
     ss = generate_secondary_structure(len(fasta))


### PR DESCRIPTION
@AlaaShamandy 

Here a straightforward script that generates dummy structural data as we discussed, script is in `alphas`.

You should execute it as follows:

`python dummy_data_generator.py #`

where `#` is the number of files (named `*.data`) you want to generate, for example, 28 :wink:

Each file contains all the data that needs to be considered, and it simulates that there is one file for each PDB used. The structure of the file is as follows, I kept it comma-separated to facilitate writing and reading.

```plain
# Residue Type, Secondary Structure, X, Y, Z, phi, psi, omge, chi1
R,H,164.473,-21.001,-63.092,9.556,91.184,63.720,65.629
T,H,-54.691,26.945,-64.885,42.886,62.590,17.801,82.702
C,H,-29.134,-58.904,35.920,131.489,28.196,93.747,11.348
F,H,118.551,-13.107,-178.011,-117.883,24.150,47.303,36.165
W,H,64.557,-133.167,-118.950,-0.566,11.026,4.768,69.736
S,H,3.119,-108.208,-79.561,179.436,46.986,54.985,95.328
```

Please note there **there is no physical meaning** in these numbers. They just represent the type of data nothing more. The **only** meaning I introduced in these files are:
* amino acid names are the real names
* secondary structure elements are stretches of 2 to 25 residues
* coordinates are any value between 0 and 100
* angles are any value between -180 and 180

Please accept this PR. We will continue the discussion in #39 