### PR TITLE
Secondary Structure Extract All parameter correction

### DIFF
--- a/src/idpconfgen/cli_ssext.py
+++ b/src/idpconfgen/cli_ssext.py
@@ -58,6 +58,7 @@ ap.add_argument(
         'A subfolder is created for each secondary structure type'
         ),
     default='all',
+    action=libcli.AllParam,
     nargs='+',
     )
 
@@ -70,6 +71,7 @@ ap.add_argument(
         ),
     default='all',  # ('N', 'CA', 'C'),
     nargs='+',
+    action=libcli.AllParam,
     )
 libcli.add_argument_minimum(ap)
 libcli.add_argument_ncores(ap)

--- a/src/idpconfgen/libs/libcli.py
+++ b/src/idpconfgen/libs/libcli.py
@@ -40,6 +40,18 @@ class ArgsToTuple(argparse.Action):
         setattr(namespace, self.dest, tuple(values))
 
 
+class AllParam(argparse.Action):
+    """Convert list of arguments in tuple."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        """Call it."""
+        if values == ['all']:
+            setattr(namespace, self.dest, 'all')
+
+        else:
+            setattr(namespace, self.dest, values)
+
+
 class CSV2Tuple(argparse.Action):
     """Convert list of arguments in tuple."""
 

--- a/src/idpconfgen/libs/libhigherlevel.py
+++ b/src/idpconfgen/libs/libhigherlevel.py
@@ -188,18 +188,23 @@ def extract_secondary_structure(
         The secondary structure character to separate.
         Multiple can be given in the form of a list.
     """
+    # caused problems in the past
+    assert atoms != ['all']
+    assert structure != ['all']
+
     pdbname = Path(pdbid[0]).stem
     pdbdata = pdbid[1].split(b'\n')
+
+    # gets PDB computed data from dictionary
     try:
         pdbdd = ssdata[pdbname]
     except KeyError:
         pdbdd = ssdata[f'{pdbname}.pdb']
 
-    ss_identified = set(pdbdd['dssp'])
     if structure == 'all':
-        ss_to_isolate = ss_identified
+        ss_to_isolate = set(pdbdd['dssp'])
     else:
-        ss_to_isolate = set(s for s in ss_identified if s in structure)
+        ss_to_isolate = set(structure)
 
     # general lines filters
     line_filters = []
@@ -214,7 +219,7 @@ def extract_secondary_structure(
 
     dssp_slices = group_by(pdbdd['dssp'])
     # DR stands for dssp residues
-    DR = [c.encode() for c in pdbdd['resids'].split(',')]
+    DR = [c for c in pdbdd['resids'].encode().split(b',')]
 
     for ss in ss_to_isolate:
 


### PR DESCRIPTION
When giving argument `all` to parameters `-s` and `-a`, `['all']` was passed to the `extract_` function, yielding incorrect behaviour.
This is corrected by applying an action at the level of the `cli_ssext`.
Added couple of improvements in the main function.