### PR TITLE
Builder accepting a generative function

### DIFF
--- a/src/idpconfgen/cli_build.py
+++ b/src/idpconfgen/cli_build.py
@@ -1,5 +1,7 @@
 """
-Builds conformers from a database of torsion angles and secondary structure
+Builds IDP conformers.
+
+Build from a database of torsion angles and secondary structure
 information. Database is as created by `idpconfgen torsions` CLI.
 
 USAGE:
@@ -10,7 +12,8 @@ import argparse
 from functools import partial
 from itertools import cycle
 from multiprocessing import Pool
-from random import choice as randchoice, randint
+from random import choice as randchoice
+from random import randint
 from time import time
 
 import numpy as np
@@ -170,7 +173,7 @@ def main_exec(
         nconfs=1,
         ):
     """
-    Builds conformers.
+    Build conformers.
 
     *Note*: `execution_run` is a positional parameter in order to maintain
     operability with the multiprocessing operations in `main`, sorry for
@@ -311,7 +314,7 @@ def main_exec(
     start_conf = nconfs * execution_run
     end_conf = start_conf + nconfs
     conf_n = start_conf
-    #for conf_n in range(start_conf, end_conf):
+    # for conf_n in range(start_conf, end_conf):
     while conf_n < end_conf:
 
         # prepares cycles for building process
@@ -511,7 +514,7 @@ def main_exec(
                     'conformers were not built.'
                     )
                 return
-            broke_on_max_attempts = False
+            broke_on_start_attempt = False
             continue
 
         # until sidechains are implemented this is needed


### PR DESCRIPTION
Hi @mojtabah 

This PR implements our discussion from yesterday regarding integrating the generative model in the builder code.

You can now send a `generative_function` to the `main_exec`. `generative_function` should receive a `nres` and `cres`, where:
* `nres` how many residues to generate angles for. So if `nres=3`, the builder would expect 15 angles in sequence `phi, psi, omega, ...`
* `cres` is the current residue being built. **Not** the last one previously built, but the one being built after receiving the angles. As defined, protein residue number, in this context, are `0-indexed`.

For the time being, I am sending a random number for `nres`. At a later stage, I will explore a better strategy if needed.

I explored some possibilities to use polymorphism, but it created too much overhead on the extra function call to mask the main procedure used by the builder. So I just went with a normal `if` statement :wink:

I assess the quality of the `generative_function` before starting the building process with a `try:catch` block.

Finally, I corrected a small bug regarding the number of attempts to try to build a conformer that had nothing to do with this discussion but because was very easy to solve (variable name typo), I corrected it directly.

I will wait for your reply before merging
Cheers,