### PR TITLE
Add N-terminal hydrogens

### DIFF
--- a/src/idpconfgen/core/build_definitions.py
+++ b/src/idpconfgen/core/build_definitions.py
@@ -676,3 +676,11 @@ sidechain_templates = {
     pdb.stem.upper(): _get_structure_coords(pdb)
     for pdb in _sidechain_template_files
     }
+
+# these template coordinates were created using Chimera-X daily given
+# a N-terminal at 0,0,0 and a CA along the X axis.
+n_terminal_h_coords_at_origin = np.array([
+    [-0.337, -0.036, 0.951],
+    [-0.336, 0.842, -0.444],
+    [-0.337, -0.806, -0.507],
+    ])


### PR DESCRIPTION
N-terminal hydrogens are added when constructing the first chunk of each conformer. A template of the hydrogens exist in the definitions and is rotated in agreement with the HA (alpha proton) of the first chunk, in order to obtain a 60 dihedral angle difference.

Adds additional minor comments and modularity at `njit` functions.

I decided to address this pending implementation before #82 because having this done first will just facilitate solving #82.