### PR TITLE
Add flag to synchronize energy threshold with sidechain addition

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ While in version ``0``, minor and patch upgrades converge in the ``patch`` numbe
 Changelog
 =========
 
+* added ``--energy-threshold`` flag to control energy threshold after sidechain addition
+
 v0.0.4 (2021-04-19)
 ------------------------------------------------------------
 

--- a/src/idpconfgen/cli_build.py
+++ b/src/idpconfgen/cli_build.py
@@ -787,6 +787,7 @@ def conformer_generator(
                 primer_template, agls = GET_ADJ(bbi - 1)
 
             # index at the start of the current cycle
+            #print(primer_template)
             PRIMER = cycle(primer_template)
             try:
                 for (omg, phi, psi) in zip(agls[0::3], agls[1::3], agls[2::3]):
@@ -928,7 +929,7 @@ def conformer_generator(
             # ?
 
             total_energy = TEMPLATE_EFUNC(template_coords)
-            #print(total_energy)
+            #print(bbi, total_energy)
 
             if total_energy > energy_threshold:
                 #print('---------- energy positive')
@@ -1032,7 +1033,7 @@ def conformer_generator(
 
             total_energy = ALL_ATOM_EFUNC(all_atom_coords)
 
-            if total_energy > 0:
+            if total_energy > energy_threshold:
                 print('Conformer with WORST energy', total_energy)
                 continue
             else:


### PR DESCRIPTION
Synchronizes flag `--energy-threshold` with threshold to accept after side-chain addition.