### PR TITLE
corrected command typo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ While in version ``0``, minor and patch upgrades converge in the ``patch`` numbe
 Changelog
 =========
 
+* corrected typo in example/ commands
+
 v0.0.14 (2021-06-05)
 ------------------------------------------------------------
 

--- a/example/README.rst
+++ b/example/README.rst
@@ -53,7 +53,7 @@ chains split into continuous chains.
 Now we need to calculate the torsion angles. There are several options available
 in the command line but these are good defaults::
 
-    idpconfgen torsions sscalc_splittled.tar -sc sscalc.json -o idpconfgen_database.json
+    idpconfgen torsions sscalc_splitted.tar -sc sscalc.json -o idpconfgen_database.json
 
 This will create the final file :code:`idpconfgen_database.json`. This is the
 file IDPConfGen needs to generate conformers. This is the torsion angle database


### PR DESCRIPTION
There was a typo in one of the example/ folder commands. Now, it is corrected.