### PR TITLE
adds output-folder option in build interface

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ While in version ``0``, minor and patch upgrades converge in the ``patch`` numbe
 Changelog
 =========
 
+* Add output-folder option for the ``build`` interface
+
 v0.0.15 (2021-06-09)
 ------------------------------------------------------------
 

--- a/src/idpconfgen/cli_build.py
+++ b/src/idpconfgen/cli_build.py
@@ -236,6 +236,8 @@ ap.add_argument(
     action=libcli.ListOfIntsPositiveSum,
     )
 
+
+libcli.add_argument_output_folder(ap)
 libcli.add_argument_random_seed(ap)
 libcli.add_argument_ncores(ap)
 
@@ -252,6 +254,7 @@ def main(
         ncores=1,
         random_seed=0,
         xmers_probs=False,
+        output_folder=None,
         **kwargs,  # other kwargs target energy function, for example.
         ):
     """
@@ -324,6 +327,7 @@ def main(
     consume = partial(
         _build_conformers,
         input_seq=input_seq,  # string
+        output_folder=output_folder,
         nconfs=conformers_per_core,  # int
         **kwargs,
         )
@@ -428,11 +432,16 @@ def _build_conformers(
         *args,
         input_seq=None,
         conformer_name='conformer',
+        output_folder=None,
         nconfs=1,
         **kwargs,
         ):
     """Arrange building of conformers and saves them to PDB files."""
     ROUND = np.round
+
+    output_folder = \
+        Path(output_folder) if output_folder is not None else Path.cwd()
+    output_folder.mkdir(parents=True, exist_ok=True)
 
     # TODO: this has to be parametrized for the different HIS types
     input_seq_3_letters = translate_seq_to_3l(input_seq)
@@ -457,7 +466,7 @@ def _build_conformers(
 
         fname = f'{conformer_name}_{CONF_NUMBER.get()}.pdb'
 
-        with open(fname, 'w') as fout:
+        with open(Path(output_folder, fname), 'w') as fout:
             fout.write(pdb_string)
 
     del builder

--- a/src/idpconfgen/libs/libcli.py
+++ b/src/idpconfgen/libs/libcli.py
@@ -261,6 +261,7 @@ def add_version(parser):
 # -m, --minimum           : minimum size
 # -n, --ncores            : number of cores
 # -o, --ouput             : general output string
+# -of, --output-folder    : output folder
 # --replace               : replace (whatever shalls replace)
 # -rd, --reduced          : reduces secondary structure representation
 # -rn, --record-name      : PDB RECORD name
@@ -399,6 +400,21 @@ def add_argument_output(parser):
         help=(
             'Output file. Defaults to `None`. '
             'Read CLI instructions for `None` behaviour.'
+            ),
+        type=str,
+        default=None,
+        )
+
+
+def add_argument_output_folder(parser):
+    """Add argument for general output string."""
+    parser.add_argument(
+        '-of',
+        '--output-folder',
+        help=(
+            "The folder where to save the output. "
+            "NOTE: if new files have the same name of old files in the "
+            "folder, new files will replace old files."
             ),
         type=str,
         default=None,

--- a/tests/test_libcli.py
+++ b/tests/test_libcli.py
@@ -163,6 +163,8 @@ def test_add_version():
         (libcli.add_argument_output, [], ['output', None]),
         (libcli.add_argument_output, ['-o', 'out.log'], ['output', 'out.log']),
         (libcli.add_argument_output, ['--output', 'out.log'], ['output', 'out.log']),
+        (libcli.add_argument_output_folder, ['--output-folder', 'myfolder'], ['output_folder', 'myfolder']),
+        (libcli.add_argument_output_folder, ['-of', 'folder'], ['output_folder', 'folder']),
         (libcli.add_argument_pdb_files, ['myfolder'], ['pdb_files', ['myfolder']]),  # noqa: E501
         (libcli.add_argument_pdb_files, ['my.tar'], ['pdb_files', 'my.tar']),
         (libcli.add_argument_pdbids, ['12AS_A'], ['pdbids', ['12AS_A']]),


### PR DESCRIPTION
With `--output-folder` the user can select a folder where the conformers will be saved.
Option suggested by @SeanR22 