### PR TITLE
changed libfuncpy reference to .yml

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ While in version ``0``, minor and patch upgrades converge in the ``patch`` numbe
 Changelog
 =========
 
+* Added libfuncpy to requirements.yml
+
 v0.0.22 (2021-06-30)
 ------------------------------------------------------------
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,4 @@
-name: idpconfgen
+name: idpconfgen_tmp
 channels:
     - conda-forge
     - defaults
@@ -13,3 +13,4 @@ dependencies:
     - tox=3
     - pip:
         - tox-conda
+        - libfuncpy>=0.0.3

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         ],
     python_requires='>=3.7.*,<4',
     install_requires=[
-        'libfuncpy>=0.0.3',
+        #'libfuncpy>=0.0.3',
         #'numpy>=1,<2',
         #'numba>=0.53.0',
         #'scipy>=1,<2',


### PR DESCRIPTION
With this update the installation instructions are maintain:

```bash
conda env create -f requirements.yml
python setup.py develop
```