### PR TITLE
corrects input command option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ While in version ``0``, minor and patch upgrades converge in the ``patch`` numbe
 Changelog
 =========
 
-* dropped tox-conda because it is not needed for this project #169
+* corrected `sscalc` from * input in command-line #175
 
 v0.2.5 (2022-03-11)
 ------------------------------------------------------------

--- a/src/idpconfgen/cli_sscalc.py
+++ b/src/idpconfgen/cli_sscalc.py
@@ -169,7 +169,7 @@ def main(
     try:
         pdbs2operate = extract_from_tar(pdb_files, output=tmpdir, ext='.pdb')
         _istarfile = True
-    except (FileNotFoundError, TypeError):
+    except (OSError, FileNotFoundError, TypeError):
         pdbs2operate = list(read_path_bundle(pdb_files, ext='pdb'))
         _istarfile = False
     log.info(S('done'))


### PR DESCRIPTION
Before:

`idpconfgen sscalc *.pdb ...`

wouldn't work. Now it does.