### PR TITLE
Add instructions to install MCSCE

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -54,7 +54,7 @@ described above. Next, follow these steps::
     conda activate idpconfgen
 
     # navigate back to the idpconfgen github folder and re-run
-    python setup-py develop --no-deps
+    python setup.py develop --no-deps
 
 Now, if you choose the flag `-scm mcsce`, IDPConfGen will use MCSCE to build
 sidechains as backbone conformers are generated. You will see `idpconfgen build


### PR DESCRIPTION
Now that [MCSCE](https://github.com/THGLab/MCSCE) is open-source we can provide proper installation instructions.