### PR TITLE
QUICKFIX: chunk sizes will be consistent now

### DIFF
--- a/src/idpconfgen/cli_build.py
+++ b/src/idpconfgen/cli_build.py
@@ -552,7 +552,7 @@ def main(
     remove_empty_keys(SLICEDICT_XMERS)
     # updates user defined chunk sizes and probabilities to the ones actually
     # observed
-    _ = compress_xmer_to_key(xmer_probs_tmp, sorted(list(SLICEDICT_XMERS.keys())))
+    _ = compress_xmer_to_key(xmer_probs_tmp, sorted(SLICEDICT_XMERS.keys()))
     XMERPROBS = _.probs
 
 
@@ -566,7 +566,7 @@ def main(
     #sys.exit()
 
     GET_ADJ = get_adjacent_angles(
-        sorted(list(SLICEDICT_XMERS.keys())),
+        sorted(SLICEDICT_XMERS.keys()),
         XMERPROBS,
         input_seq,
         ANGLES,

--- a/src/idpconfgen/components/xmer_probs.py
+++ b/src/idpconfgen/components/xmer_probs.py
@@ -83,16 +83,16 @@ class XmerProbsAction(Action):
 xmers_prob_help = """Size of peptide building chunks and their respective
 selection probabilities.
 
-Provide a too column file where the first column is the size of the chunks you
-wish to allow and the second column is the relative probability to select each
-choice. Both columns must be integers. Use "#" to comment lines. If you don't
-provide any value, the default is chunk sizes: 1 to 5 with relative
-probabilities (1, 1, 3, 3, 2). You can give any integer to define relative
-probabilities: 10 and 90 will results 10/(10+90) and 90/(10+90) percent.
-If a Proline residue follows the chunk being built, the additional Proline
-angles will also be consider regardless of the selected chunk size.
-Chunk sizes will be ignored if no matches are found in the database and the
-probabilities renormalized."""
+Provide a two column file where the first column is the size of the chunks you
+wish to allow **in order from smallest to largest** and the second column is 
+the relative probability to select each choice. Both columns must be integers.
+Use "#" to comment lines. If you don't provide any value, the default is 
+chunk sizes: 1 to 5 with relative probabilities (1, 1, 3, 3, 2). You can 
+give any integer to define relativeprobabilities: 10 and 90 will results 
+10/(10+90) and 90/(10+90) percent. If a Proline residue follows the chunk 
+being built, the additional Prolineangles will also be consider regardless
+of the selected chunk size. Chunk sizes will be ignored if no matches are 
+found in the database and the probabilities renormalized."""
 
 xmer_probs_args = ['-xp', '--xmer-probs']
 xmer_probs_kwargs = {


### PR DESCRIPTION
Noticed an issue while working on Graham that chunks of 2, 3, 4, 5 weren't building correctly. It seems that the chunk sizes were being changed after `SLICEDICT_XMERS` were created. (E.g. `[1,2,3,4,5]` in the text file for `-xp` was changed to something like `[1,2,4,5,3]` after processing and the probabilities stayed the same so they were not going to line up as the user intended).

I implemented a quickfix where the list of xmers will be sorted from smallest to greatest per user definition for `-xp`. This could probably be done better by implementing a dictionary before hand matching the user defined chunks to probabilities, and after "updates[sic] user defined chunk sizes and probabilities to the ones actually observed", reorganize each chunk's respective probabilities.