### PR TITLE
Fix input sequence processing for single chains in `ldrs`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ While in version ``0``, minor and patch upgrades converge in the ``patch`` numbe
 Changelog
 =========
 
+* Bug-fix in ``ldrs`` for input sequence recognition
+
 v0.7.7 (2023-09-26)
 ------------------------------------------------------------
 

--- a/src/idpconfgen/cli_ldrs.py
+++ b/src/idpconfgen/cli_ldrs.py
@@ -474,14 +474,20 @@ def main(
     
     # Accomodate multiple chains in template
     global MULTICHAIN
-    if len(input_seq) > 1:
-        log.info(T('multiple sequences detected. assuming they are in a multi-chain complex'))  # noqa: E501
-        for chain in input_seq:
-            log.info(S(f'{chain}: {input_seq[chain]}'))
-        MULTICHAIN = True
+    if type(input_seq) is dict:
+        if len(input_seq) > 1:
+            log.info(T('multiple sequences detected. assuming they are in a multi-chain complex'))  # noqa: E501
+            for chain in input_seq:
+                log.info(S(f'{chain}: {input_seq[chain]}'))
+            MULTICHAIN = True
+        else:
+            single_seq = list(input_seq.values())[0]
+            log.info(S(f'input sequence: {single_seq}'))
+    # For the case when the user just enters sequence without .fasta
     else:
-        single_seq = list(input_seq.values())[0]
-        log.info(S(f'input sequence: {single_seq}'))
+        log.info(S(f'input sequence: {input_seq}'))
+        # convert input_seq to a dict because that's how we will process
+        input_seq = {"A": input_seq}
     
     # Calculates how many conformers are built per core
     if nconfs < ncores:


### PR DESCRIPTION
Minor bug occurs when users don't use `.fasta` in the `ldrs` subclient. Fixed by processing plain-text into dict.