### PR TITLE
Corrects reading CIF files without `#` end block

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Changelog
 =========
 
 * Correct reading CIF files without `#` end block.
+* Fix minor bugs for reading CIF templates in ``ldrs``
 
 v0.7.9 (2023-10-27)
 ------------------------------------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ While in version ``0``, minor and patch upgrades converge in the ``patch`` numbe
 Changelog
 =========
 
+* Correct reading CIF files without `#` end block.
+
 v0.7.9 (2023-10-27)
 ------------------------------------------------------------
 

--- a/src/idpconfgen/libs/libcif.py
+++ b/src/idpconfgen/libs/libcif.py
@@ -263,6 +263,9 @@ def populate_cif_dictionary(lines, start_index, cif_dict):
     """
     Populate mmCIF dictionary.
 
+    Expects atom coordinate information to be consecutive, otherwise
+    reading will be incomplete or errors will occur.
+
     Parameters
     ----------
     lines : list
@@ -270,7 +273,8 @@ def populate_cif_dictionary(lines, start_index, cif_dict):
 
     start_index : int
         The line index, that is, line number 0-indexed, where the
-        actual `atom_site.` structural information starts.
+        actual `atom_site.` structural information starts, that is,
+        the first ATOM/HETATM line.
 
     cif_dict : dict
         The mmCIF dictionary to populate. The dict keys should be

--- a/src/idpconfgen/libs/libcif.py
+++ b/src/idpconfgen/libs/libcif.py
@@ -1,4 +1,5 @@
 """Handle CIF data."""
+import os
 import re
 
 from idpconfgen.core import exceptions as EXCPTS
@@ -13,7 +14,7 @@ class CIFParser:
     Parameters
     ----------
     datastr : str
-        The contect of the mmCIF file in string format.
+        The content of the mmCIF file in string format.
     """
 
     __slots__ = [
@@ -37,7 +38,7 @@ class CIFParser:
 
     def read_cif(self, datastr):
         """Read 'atom_site.' entries to dictionary."""
-        lines = datastr.split('\n')
+        lines = datastr.split(os.linesep)
         atom_start_index = find_cif_atom_site_headers(lines, self.cif_dict)
         self._len = populate_cif_dictionary(
             lines,
@@ -294,7 +295,12 @@ def populate_cif_dictionary(lines, start_index, cif_dict):
 
     valid_len = len(cif_dict)
     for counter, line in enumerate(lines[start_index:]):
-        if line.startswith('#'):
+        # expects all coordinate related lines to be consecutive
+        # Usually the coordinate block ends with an "#"
+        # but if the coordinate block is the end of the file the "#"
+        # may be missing. Hence the `or not line`.
+        # Closes issue #
+        if line.startswith('#') or not line:
             return counter
 
         ls = parse_cif_line(line)

--- a/tests/test_libcif.py
+++ b/tests/test_libcif.py
@@ -16,7 +16,6 @@ from .tcommons import (
     cif_example_auth,
     cif_example_headers,
     cif_example_noasymid,
-    cif_nohash,
     )
 
 
@@ -75,10 +74,14 @@ def test_find_cif_atom_site_headers_keys(fix_find_cif_atom_site_headers):
     assert all(k.startswith('_atom_site.') for k in cif_pdb.keys())
 
 
-def test_fine_cif_atom_site_headers_error():
+@pytest.mark.parametrize(
+    'input_',
+    ([' ', 'something'], ['']),
+    )
+def test_fine_cif_atom_site_headers_error(input_):
     """Test missing atom_site headers error."""
     with pytest.raises(EXCPTS.CIFFileError):
-        find_cif_atom_site_headers([' ', 'somestring'], {})
+        find_cif_atom_site_headers(input_, {})
 
 
 def test_populate_cif_dictionary(fix_find_cif_atom_site_headers):
@@ -102,16 +105,19 @@ def test_populate_cif_dictionary(fix_find_cif_atom_site_headers):
             22,
             {i: [] for i in cif_example_headers},
             ),
-        (
-            cif_nohash.read_text().split('\n'),
-            22,
-            {i: [] for i in cif_example_headers},
-            ),
-        (
-            [''],
-            0,
-            {'_atom_site.id': []},
-            ),
+        # removed after #255, no hash is no longer a problem
+        # (
+        #     cif_nohash.read_text().split('\n'),
+        #     22,
+        #     {i: [] for i in cif_example_headers},
+        #     ),
+        # should not modify the dictionary if not coordinate lines
+        # are present.
+        # (
+        #     [''],
+        #     0,
+        #     {'_atom_site.id': []},
+        #     ),
         ]
     )
 def test_populate_cif_dictionary_errors(args):


### PR DESCRIPTION
Solves #255 

If another end block character appears in the future, add that case to the modified lines here.