### PR TITLE
Update citing information

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ While in version ``0``, minor and patch upgrades converge in the ``patch`` numbe
 Changelog
 =========
 
+* Update citing information.
+
 v0.7.10 (2023-10-27)
 ------------------------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -49,14 +49,14 @@ How to cite
 
 .. start-citing
 
-If you use IDPConformerGenerator, please cite::
+If you use IDPConformerGenerator, please always cite its original publication::
 
     IDPConformerGenerator: A Flexible Software Suite for Sampling the Conformational Space of Disordered Protein States
     João M. C. Teixeira, Zi Hao Liu, Ashley Namini, Jie Li, Robert M. Vernon, Mickaël Krzeminski, Alaa A. Shamandy, Oufan Zhang, Mojtaba Haghighatlari, Lei Yu, Teresa Head-Gordon, and Julie D. Forman-Kay
     The Journal of Physical Chemistry A 2022 126 (35), 5985-6003
     DOI: 10.1021/acs.jpca.2c03726
 
-If you use the Local Disordered Region Sampling (LDRS) module, please cite::
+If you use the Local Disordered Region Sampling (LDRS) module, please also cite::
 
     Local Disordered Region Sampling (LDRS) for Ensemble Modeling of Proteins with Experimentally Undetermined or Low Confidence Prediction Segments
     Zi Hao Liu, João M.C. Teixeira, Oufan Zhang, Thomas E. Tsangaris, Jie Li, Claudiu C. Gradinaru, Teresa Head-Gordon, Julie D. Forman-Kay


### PR DESCRIPTION
Updates the `REAMDE` to clarify that the original IDPCG publication should always be cited and, in addition, submodules' publications should be cited additionally when used.