### PR TITLE
Update `sscalc` DSSP defaults and clarify documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ While in version ``0``, minor and patch upgrades converge in the ``patch`` numbe
 Changelog
 =========
 
+* Update documentation for DSSP due to clarity with version requirements
+* Set default of ``-cmd`` in ``sscalc`` to ``mkdssp``
+
 v0.7.11 (2023-11-02)
 ------------------------------------------------------------
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -131,8 +131,10 @@ structures. However, you only need DSSP if you are generated the database from
 scratch. If you use a prepared database JSON file you don't need to install
 DSSP.
 
-To install DSSP, please refer to:
-https://github.com/julie-forman-kay-lab/IDPConformerGenerator/issues/48
+Please note we are only compatible with DSSP versions 2 and 3. If you have
+installed DSSP version 4 (check by using the command ``mkdssp --version``) please
+refer `to this issue <https://github.com/julie-forman-kay-lab/IDPConformerGenerator/issues/48>`_
+for a proper re-installation after removing DSSP version 4.
 
 Install MC-SCE
 ``````````````

--- a/src/idpconfgen/cli_sscalc.py
+++ b/src/idpconfgen/cli_sscalc.py
@@ -60,8 +60,8 @@ libcli.add_argument_pdb_files(ap)
 ap.add_argument(
     '-cmd',
     '--dssp_cmd',
-    help="Path the do DSSP executable. Defaults to `dssp`.",
-    default="dssp",
+    help="Shell command for the DSSP executable. Defaults to `mkdssp`.",
+    default="mkdssp",
     )
 
 ap.add_argument(


### PR DESCRIPTION
There have been issues with users using DSSP V4.X instead of V2.X or V3.X, we have clarified this in the documentation (both RtD and CLI) as well as changed the default in the `sscalc -cmd dssp` to `sscalc -cmd mkdssp` to align with installation instructions in #48 